### PR TITLE
feat: yaml file translation

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@vercel/analytics": "^0.1.11",
     "@vercel/node": "^2.9.12",
     "@zip.js/zip.js": "^2.6.78",
+    "js-yaml": "^4.1.0",
     "monaco-editor": "^0.36.1",
     "openai": "^3.2.1",
     "react": "^18.2.0",
@@ -30,6 +31,7 @@
     "vercel": "^28.16.15"
   },
   "devDependencies": {
+    "@types/js-yaml": "^4.0.5",
     "@types/react": "^18.0.27",
     "@types/react-dom": "^18.0.10",
     "@vitejs/plugin-react": "^3.1.0",

--- a/src/pages/translate/config.ts
+++ b/src/pages/translate/config.ts
@@ -12,3 +12,8 @@ export const intlLanguages: IDropdownSelectOption[] = [
     { value: "Russian", label: "Русский" },
     { value: "Chinese", label: "中文" },
 ];
+
+export const fileTypes: IDropdownSelectOption[] = [
+    { value: "json", label: "json" },
+    { value: "yaml", label: "yaml" },
+];

--- a/src/pages/translate/exportFiles.tsx
+++ b/src/pages/translate/exportFiles.tsx
@@ -4,11 +4,14 @@ import { intlLanguages } from "./config";
 import { downloadFileFromBlob, exportLocalFiles, makeLocalesInZip } from "./services";
 import Spinner from "../../components/spinner";
 import { useNotification } from "../../notify";
-import { compressJson } from "./utils";
+import { compress } from "./utils";
+import { FileType } from "./types";
 
 interface ExportFilesProps {
     originalContent: string;
+    fileType: FileType;
 }
+
 const ExportFiles: React.FC<ExportFilesProps> = (props) => {
     const { originalContent } = props;
     const [show, setShow] = useState<boolean>(false);
@@ -25,19 +28,22 @@ const ExportFiles: React.FC<ExportFilesProps> = (props) => {
         }
     };
 
-    async function downloadFiles () {
+    async function downloadFiles() {
         setLoading(true);
         try {
-            const compressedContent = compressJson(originalContent);
-            const res = await exportLocalFiles(compressedContent, selectedLangs)
-            const file = await makeLocalesInZip(res)
-            downloadFileFromBlob(file, "locales.zip")
+            const compressedContent = compress(originalContent, props.fileType);
+            const res = await exportLocalFiles(compressedContent, selectedLangs, props.fileType);
+            const file = await makeLocalesInZip(res, props.fileType);
+            downloadFileFromBlob(file, "locales.zip");
         } catch (error) {
-            notify({
-                title: "export files error",
-                message: `${error}`,
-                type: "error",
-            }, 3000)
+            notify(
+                {
+                    title: "export files error",
+                    message: `${error}`,
+                    type: "error",
+                },
+                3000
+            );
         } finally {
             setLoading(false);
             setShow(false);
@@ -48,7 +54,7 @@ const ExportFiles: React.FC<ExportFilesProps> = (props) => {
         <span>
             <button
                 type="button"
-                className="ml-2 px-6 rounded bg-indigo-600 shadow-indigo-500/50 py-1.5 px-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500"
+                className="ml-2 rounded bg-indigo-600 shadow-indigo-500/50 py-1.5 px-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500"
                 onClick={() => {
                     setShow(true);
                 }}
@@ -87,12 +93,12 @@ const ExportFiles: React.FC<ExportFilesProps> = (props) => {
                         ))}
                     </div>
                 </fieldset>
-                {
-                    loading &&<div className="flex justify-center py-2">
+                {loading && (
+                    <div className="flex justify-center py-2">
                         <Spinner />
                         <h2 className="text-base font-white">Generate locale files</h2>
                     </div>
-                }
+                )}
             </Modal>
         </span>
     );

--- a/src/pages/translate/index.tsx
+++ b/src/pages/translate/index.tsx
@@ -9,14 +9,15 @@ import tsWorker from "monaco-editor/esm/vs/language/typescript/ts.worker?worker"
 import Header from "../../components/header";
 import Background from "../../components/background";
 import DropdownSelect from "../../components/dropdownSelect";
-import { compressJson, copy2Clipboard, prettierJson } from "./utils";
+import { compress, copy2Clipboard, prettierJson } from "./utils";
 import ExportFiles from "./exportFiles";
 import { DocumentDuplicateIcon } from "@heroicons/react/24/outline";
-import { intlLanguages } from "./config";
+import { fileTypes, intlLanguages } from "./config";
 import { translate } from "./services";
 import Spinner from "../../components/spinner";
 import { useNotification } from "../../notify";
 import TextField from "../../components/textField";
+import { FileType } from "./types";
 
 self.MonacoEnvironment = {
     getWorker(_, label) {
@@ -45,24 +46,28 @@ const Translate: React.FC = (props) => {
     const [transContent, setTransContent] = useState("");
     const [extraPrompt, setExtraPrompt] = useState("");
     const [loading, setLoading] = useState<boolean>(false);
+    const [fileType, setFileType] = useState<FileType>("json");
     const { notify } = useNotification();
 
     const requestTranslation = useCallback(async () => {
         setLoading(true);
         try {
-            const compressedContent = compressJson(originalContent);
-            const data = await translate(compressedContent, lang, extraPrompt);
-            setTransContent(prettierJson(data));
+            const compressedContent = compress(originalContent, fileType);
+            const data = await translate(compressedContent, lang, fileType, extraPrompt);
+            setTransContent(prettierJson(data, fileType));
         } catch (error) {
-            notify({
-                title: "translate service error",
-                message: `${error}`,
-                type: "error",
-            }, 3000)
+            notify(
+                {
+                    title: "translate service error",
+                    message: `${error}`,
+                    type: "error",
+                },
+                3000
+            );
         } finally {
             setLoading(false);
         }
-    }, [originalContent, lang, extraPrompt]);
+    }, [originalContent, lang, fileType, extraPrompt]);
 
     return (
         <div className="text-white">
@@ -75,19 +80,24 @@ const Translate: React.FC = (props) => {
                         buttonClassName="w-full"
                         options={intlLanguages}
                         selectedKey={lang}
-                        onSelect={(val) => {
-                            setLang(val);
-                        }}
+                        onSelect={(val) => setLang(val)}
+                    />
+                    <DropdownSelect
+                        className="inline-block w-28 pl-2"
+                        buttonClassName="w-full"
+                        options={fileTypes}
+                        selectedKey={fileType}
+                        onSelect={(val) => setFileType(val as FileType)}
                     />
                     <button
                         type="button"
-                        className="ml-2 px-6 inline-flex rounded bg-indigo-600 shadow-indigo-500/50 py-1.5 px-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500"
+                        className="ml-2 inline-flex rounded bg-indigo-600 shadow-indigo-500/50 py-1.5 px-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500"
                         onClick={requestTranslation}
                     >
                         {loading && <Spinner />}
                         Translate
                     </button>
-                    <ExportFiles originalContent={originalContent} />
+                    <ExportFiles originalContent={originalContent} fileType={fileType} />
                 </div>
                 <div className="mt-2">
                     <TextField
@@ -108,7 +118,7 @@ const Translate: React.FC = (props) => {
                                 setOriginalContent(val ?? "");
                             }}
                             height="600px"
-                            language="json"
+                            language={fileType}
                             theme="vs-dark"
                         />
                     </div>
@@ -118,11 +128,14 @@ const Translate: React.FC = (props) => {
                             <DocumentDuplicateIcon
                                 onClick={() => {
                                     copy2Clipboard(transContent);
-                                    notify({
-                                        type: 'success',
-                                        title: 'copied!',
-                                        message: 'copy to clipboard',
-                                    }, 1000)
+                                    notify(
+                                        {
+                                            type: "success",
+                                            title: "copied!",
+                                            message: "copy to clipboard",
+                                        },
+                                        1000
+                                    );
                                 }}
                                 className="float-right w-5 text-white cursor-pointer hover:scale-110"
                             />
@@ -133,7 +146,7 @@ const Translate: React.FC = (props) => {
                             // }}
                             value={transContent}
                             height="600px"
-                            language="json"
+                            language={fileType}
                             theme="vs-dark"
                         />
                     </div>

--- a/src/pages/translate/services.ts
+++ b/src/pages/translate/services.ts
@@ -1,6 +1,8 @@
 import { BlobWriter, ZipWriter, TextReader } from "@zip.js/zip.js";
+import { FileType } from "./types";
+import yaml from "js-yaml";
 
-export async function translate(content: string, targetLang: string, extraPrompt?: string) {
+export async function translate(content: string, targetLang: string, fileType: FileType, extraPrompt?: string) {
     const res = await fetch("/api/fastTranslate", {
         method: "POST",
         headers: {
@@ -14,13 +16,16 @@ export async function translate(content: string, targetLang: string, extraPrompt
     })
     const data = await res.json();
     if (data.success) {
+        if (fileType === "yaml") {
+            return yaml.dump(JSON.parse(data.data))
+        }
         return data.data
     } else {
         throw new Error(data.message)
     }
 }
 
-export async function exportLocalFiles(content: string, langList: string[]) {
+export async function exportLocalFiles(content: string, langList: string[], fileType: FileType) {
     const res = await fetch("/api/exportLocalFiles", {
         method: "POST",
         headers: {
@@ -33,21 +38,26 @@ export async function exportLocalFiles(content: string, langList: string[]) {
     })
     const data = await res.json();
     if (data.success) {
+        if (fileType === "yaml") {
+            for (let i = 0; i < data.data.length; i++) {
+                data.data[i].content = yaml.dump(JSON.parse(data.data[i].content))
+            }
+        }
         return data.data
     } else {
         throw new Error(data.message)
     }
 }
 
-export async function makeLocalesInZip (data: { lang: string, content: string }[]): Promise<File> {
+export async function makeLocalesInZip (data: { lang: string, content: string }[], fileType: FileType): Promise<File> {
     const zipFileWriter = new BlobWriter();
     const zipWriter = new ZipWriter(zipFileWriter);
     for (let item of data) {
         const content = new TextReader(item.content);
-        await zipWriter.add(`${item.lang}.json`, content);
+        await zipWriter.add(`${item.lang}.${fileType}`, content);
     }
     const blob = await zipWriter.close();
-    return new File([blob], 'locales.json');
+    return new File([blob], `locales.${fileType}`);
 }
 
 export function downloadFileFromBlob(content: Blob, fileName: string) {

--- a/src/pages/translate/types.ts
+++ b/src/pages/translate/types.ts
@@ -1,0 +1,1 @@
+export type FileType = "json" | "yaml";

--- a/src/pages/translate/utils.ts
+++ b/src/pages/translate/utils.ts
@@ -1,14 +1,17 @@
-export function compressJson(content: string): string {
+import { FileType } from "./types"
+import yaml from "js-yaml";
+
+export function compress(content: string, fileType: FileType): string {
     try {
-        return JSON.stringify(JSON.parse(content))
+        return fileType === "json" ? JSON.stringify(JSON.parse(content)) : JSON.stringify(yaml.load(content)) as string;
     } catch (error) {
-        throw new Error('json is not valid')
+        throw new Error(`${fileType} is not valid`)
     }
 }
 
-export function prettierJson(content: string): string {
+export function prettierJson(content: string, fileType: FileType): string {
     try {
-        return JSON.stringify(JSON.parse(content), null, 2)
+        return fileType === "json" ? JSON.stringify(JSON.parse(content), null, 2) : yaml.dump(yaml.load(content)) as string;
     } catch (error) {
         throw new Error('json is not valid')
     }


### PR DESCRIPTION
@ObservedObserver @laterdayi I have added an option to translate `yaml` files.  This was achieved by converting the `yaml` files to `json` before translating, and then converting back after translation. It relies on the `js-yaml` package.

Closes #9. #11 is also in development.