### PR TITLE
feat: translate XML files

### DIFF
--- a/api/fastTranslate.ts
+++ b/api/fastTranslate.ts
@@ -1,20 +1,20 @@
 import type { VercelRequest, VercelResponse } from "@vercel/node";
-import { Configuration, OpenAIApi, ChatCompletionRequestMessage } from 'openai'
-import { buildJsonByPairs, compressValuesInJson, groupPairs } from "./utils/utils.js";
+import { ChatCompletionRequestMessage, Configuration, OpenAIApi } from "openai";
+import { FileType, buildJsonByPairs, compressValuesInJson, groupPairs, mergeAndSortPairs } from "./utils/utils.js";
 // import { buildJsonByPairs, compressValuesInJson, groupPairs } from '../lib/utils/index'
 
-function matchJSON (str: string) {
+function matchJSON(str: string) {
     let start = 0;
     let end = 0;
     let stack: string[] = [];
     for (let i = 0; i < str.length; i++) {
-        if (str[i] === '[') {
+        if (str[i] === "[") {
             if (stack.length === 0) {
                 start = i;
             }
-            stack.push('[');
+            stack.push("[");
         }
-        if (str[i] === ']') {
+        if (str[i] === "]") {
             stack.pop();
             if (stack.length === 0) {
                 end = i;
@@ -28,61 +28,69 @@ function matchJSON (str: string) {
 interface IReqBody {
     content: string;
     targetLang: string;
+    fileType: FileType;
     extraPrompt?: string;
 }
 export default async function handler(request: VercelRequest, response: VercelResponse) {
     const params = request.body as IReqBody;
-    const { content, targetLang, extraPrompt } = params;
+    const { content, targetLang, fileType, extraPrompt } = params;
     try {
         const configuration = new Configuration({
             apiKey: process.env.OPENAI_API_KEY,
         });
         const openai = new OpenAIApi(configuration);
         const locale = JSON.parse(content);
-        const pairs: [string, any][] = []
-        compressValuesInJson(locale, '', pairs);
+        const pairs: [string, any][] = [];
+        compressValuesInJson(locale, "", pairs);
 
-        const { requireTranslation, noTranslation } = groupPairs(pairs)
+        let { requireTranslation, noTranslation } = groupPairs(pairs, fileType);
         const messages: ChatCompletionRequestMessage[] = [
             {
                 role: "system",
                 content: `You are a helpful assistant that translates a i18n locale array content to ${targetLang}. 
                 It's a array structure, contains many strings, translate each of them and make a new array of translated strings.
                 Consider all the string as a context to make better translation.\n`,
-            }
-        ]
-        if (typeof extraPrompt === 'string' && extraPrompt.length > 0) {
+            },
+        ];
+        if (typeof extraPrompt === "string" && extraPrompt.length > 0) {
             messages.push({
-                role: 'user',
+                role: "user",
                 content: `Other tips for translation: ${extraPrompt}\n
-                Translate this array:`
-            })
+                Translate this array:`,
+            });
         }
+
         messages.push({
             role: "user",
-            content: JSON.stringify(requireTranslation.map(t => t[1]))
-        })
+            content: JSON.stringify(requireTranslation.map((t) => t[0][1])),
+        });
+
         const completion = await openai.createChatCompletion({
             model: "gpt-3.5-turbo",
-            messages
+            messages,
         });
+
         const translatedRaw = matchJSON(`${completion.data.choices[0].message?.content}`);
         // const translatedRaw = matchJSON(`${JSON.stringify(requireTranslation)}`);
 
         const translated = JSON.parse(translatedRaw) as string[];
 
-        const nextPairs = (translated.map((t, i) => [requireTranslation[i][0], t]) as [string, string][]).concat(noTranslation);
+        const nextPairs = mergeAndSortPairs(
+            requireTranslation.map((t, i) => [[t[0][0], translated[i]], t[1]]),
+            noTranslation
+        );
+
         const result = buildJsonByPairs(nextPairs);
         response.status(200).json({
             success: true,
-            data: JSON.stringify(result)
+            data: JSON.stringify(result),
         });
     } catch (error) {
-        console.log(error)
+        console.log(error);
         response.status(500).json({
             success: false,
-            message: '[/translate] Translating services failed',
-            info: `${error}`
-        })
+            message: "[/translate] Translating services failed",
+            info: `${error}`,
+        });
     }
 }

--- a/api/utils/utils.ts
+++ b/api/utils/utils.ts
@@ -1,10 +1,12 @@
+export type FileType = "json" | "yaml" | "xml";
+
 // this is an non-accurate way to estimate token numbers;
 // content is a json string
 // estimate the word count in content and return the word count
 export function estimateTokenCount(content: any): number {
-    console.log(content)
-    if (typeof content === 'string') {
-        return content.split(' ').length;
+    console.log(content);
+    if (typeof content === "string") {
+        return content.split(" ").length;
     }
     if (content instanceof Array) {
         let count = 0;
@@ -13,73 +15,95 @@ export function estimateTokenCount(content: any): number {
         }
         return count;
     }
-    if (typeof content === 'object') {
+    if (typeof content === "object") {
         let count = 0;
         for (let key in content) {
             count += estimateTokenCount(content[key]);
         }
         return count;
     }
-    return 1
+    return 1;
 }
 
-export function compressValuesInJson (conentJson: any, path: string, pairs: [string, any][]) {
-    if (typeof conentJson === 'object') {
-        Object.keys(conentJson).forEach(k => {
-            let p = path
+export function compressValuesInJson(conentJson: any, path: string, pairs: [string, any][]) {
+    if (typeof conentJson === "object") {
+        Object.keys(conentJson).forEach((k) => {
+            let p = path;
             if (p.length !== 0) {
-                p += '.'
+                p += ".";
             }
             p += k;
-            if (typeof conentJson[k] !== 'object') {
-                pairs.push([p, conentJson[k]])
+            if (typeof conentJson[k] !== "object") {
+                pairs.push([p, conentJson[k]]);
             } else {
-                compressValuesInJson(conentJson[k], p, pairs)
+                compressValuesInJson(conentJson[k], p, pairs);
             }
-        })
+        });
     } else {
-        pairs.push([path, conentJson])
+        pairs.push([path, conentJson]);
     }
 }
 
 /**
  * group pairs into two category, pairs need to be translated or not
- * @param pairs 
+ * @param pairs
  */
-export function groupPairs (pairs: [string, any][]): {
-    requireTranslation: [string, string][],
-    noTranslation: [string, any][]
+export function groupPairs(
+    pairs: [string, any][],
+    fileType: FileType
+): {
+    requireTranslation: [[string, string], number][];
+    noTranslation: [[string, any], number][];
 } {
-    const requireTranslation: [string, string][] = [];
-    const noTranslation: [string, string][] = [];
-    for (let pair of pairs) {
-        if (typeof pair[1] === 'string') {
-            requireTranslation.push(pair)
+    const requireTranslation: [[string, string], number][] = [];
+    const noTranslation: [[string, any], number][] = [];
+    for (const [i, pair] of pairs.entries()) {
+        // if it is an XML, don't translate the attributes
+        if (typeof pair[1] === "string" && !(fileType === "xml" && pair[0].split(".").pop()?.startsWith("@_"))) {
+            requireTranslation.push([pair, i]);
         } else {
-            noTranslation.push(pair)
+            noTranslation.push([pair, i]);
         }
     }
     return {
         requireTranslation,
-        noTranslation
-    }
+        noTranslation,
+    };
 }
 
-export function buildJsonByPairs (pairs: [string, any][]) {
+/**
+ * merge two pairs and sort them based on the index
+ * @param requireTranslation
+ * @param noTranslation
+ * @returns sortedPairs
+ */
+export function mergeAndSortPairs(
+    requireTranslation: [[string, string], number][],
+    noTranslation: [[string, any], number][]
+): [string, any][] {
+    const combined = [...requireTranslation, ...noTranslation];
+
+    // Remove the index and sort based on it
+    const sortedPairs = combined.sort((a, b) => a[1] - b[1]).map((pair) => pair[0]);
+
+    return sortedPairs;
+}
+
+export function buildJsonByPairs(pairs: [string, any][]) {
     let ans: any = {};
     for (let pair of pairs) {
         const path = pair[0];
-        const keys = path.split('.');
+        const keys = path.split(".");
         let kIndex = 0;
         let node = ans;
         while (kIndex < keys.length - 1) {
-            if (typeof node[keys[kIndex]] === 'undefined') {
-                node[keys[kIndex]] = {} as any
+            if (typeof node[keys[kIndex]] === "undefined") {
+                node[keys[kIndex]] = {} as any;
             }
-            node = node[keys[kIndex]]
+            node = node[keys[kIndex]];
             kIndex++;
         }
-        node[keys[kIndex]] = pair[1]
+        node[keys[kIndex]] = pair[1];
     }
     return ans;
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@vercel/analytics": "^0.1.11",
     "@vercel/node": "^2.9.12",
     "@zip.js/zip.js": "^2.6.78",
+    "fast-xml-parser": "^4.2.2",
     "js-yaml": "^4.1.0",
     "monaco-editor": "^0.36.1",
     "openai": "^3.2.1",

--- a/src/pages/translate/config.ts
+++ b/src/pages/translate/config.ts
@@ -16,4 +16,5 @@ export const intlLanguages: IDropdownSelectOption[] = [
 export const fileTypes: IDropdownSelectOption[] = [
     { value: "json", label: "json" },
     { value: "yaml", label: "yaml" },
+    { value: "xml", label: "xml" },
 ];

--- a/src/pages/translate/exportFiles.tsx
+++ b/src/pages/translate/exportFiles.tsx
@@ -1,11 +1,10 @@
 import React, { useState } from "react";
 import Modal from "../../components/modal";
-import { intlLanguages } from "./config";
-import { downloadFileFromBlob, exportLocalFiles, makeLocalesInZip } from "./services";
 import Spinner from "../../components/spinner";
 import { useNotification } from "../../notify";
-import { compress } from "./utils";
-import { FileType } from "./types";
+import { intlLanguages } from "./config";
+import { downloadFileFromBlob, exportLocalFiles, makeLocalesInZip } from "./services";
+import { FileType, compress } from "./utils";
 
 interface ExportFilesProps {
     originalContent: string;
@@ -54,7 +53,7 @@ const ExportFiles: React.FC<ExportFilesProps> = (props) => {
         <span>
             <button
                 type="button"
-                className="ml-2 px-6 rounded bg-indigo-500 shadow-indigo-500/50 py-1.5 px-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500"
+                className="ml-2 rounded bg-indigo-500 shadow-indigo-500/50 py-1.5 px-6 text-sm font-semibold text-white shadow-sm hover:bg-indigo-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500"
                 onClick={() => {
                     setShow(true);
                 }}

--- a/src/pages/translate/index.tsx
+++ b/src/pages/translate/index.tsx
@@ -9,7 +9,7 @@ import tsWorker from "monaco-editor/esm/vs/language/typescript/ts.worker?worker"
 import Header from "../../components/header";
 import Background from "../../components/background";
 import DropdownSelect from "../../components/dropdownSelect";
-import { compress, copy2Clipboard, prettierJson } from "./utils";
+import { compress, copy2clipboard, prettify } from "./utils";
 import ExportFiles from "./exportFiles";
 import { DocumentDuplicateIcon } from "@heroicons/react/24/outline";
 import { fileTypes, intlLanguages } from "./config";
@@ -17,7 +17,8 @@ import { translate } from "./services";
 import Spinner from "../../components/spinner";
 import { useNotification } from "../../notify";
 import TextField from "../../components/textField";
-import { FileType } from "./types";
+import { FileType } from "./utils";
+import xml from "fast-xml-parser";
 
 self.MonacoEnvironment = {
     getWorker(_, label) {
@@ -54,7 +55,7 @@ const Translate: React.FC = (props) => {
         try {
             const compressedContent = compress(originalContent, fileType);
             const data = await translate(compressedContent, lang, fileType, extraPrompt);
-            setTransContent(prettierJson(data, fileType));
+            setTransContent(prettify(data, fileType));
         } catch (error) {
             notify(
                 {
@@ -91,7 +92,7 @@ const Translate: React.FC = (props) => {
                     />
                     <button
                         type="button"
-                        className="ml-2 px-6 inline-flex rounded bg-indigo-500 shadow-indigo-500/50 py-1.5 px-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500"
+                        className="ml-2 inline-flex rounded bg-indigo-500 shadow-indigo-500/50 py-1.5 px-6 text-sm font-semibold text-white shadow-sm hover:bg-indigo-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500"
                         onClick={requestTranslation}
                     >
                         {loading && <Spinner />}
@@ -127,7 +128,7 @@ const Translate: React.FC = (props) => {
                             Translated locale
                             <DocumentDuplicateIcon
                                 onClick={() => {
-                                    copy2Clipboard(transContent);
+                                    copy2clipboard(transContent);
                                     notify(
                                         {
                                             type: "success",

--- a/src/pages/translate/services.ts
+++ b/src/pages/translate/services.ts
@@ -1,6 +1,7 @@
 import { BlobWriter, ZipWriter, TextReader } from "@zip.js/zip.js";
-import { FileType } from "./types";
+import { FileType } from "./utils";
 import yaml from "js-yaml";
+import { xmlBuilder } from "./utils";
 
 export async function translate(content: string, targetLang: string, fileType: FileType, extraPrompt?: string) {
     const res = await fetch("/api/fastTranslate", {
@@ -10,18 +11,22 @@ export async function translate(content: string, targetLang: string, fileType: F
         },
         body: JSON.stringify({
             content,
-            targetLang: targetLang,
-            extraPrompt
+            targetLang,
+            fileType,
+            extraPrompt,
         }),
-    })
+    });
     const data = await res.json();
     if (data.success) {
-        if (fileType === "yaml") {
-            return yaml.dump(JSON.parse(data.data))
+        if (fileType === "xml") {
+            return xmlBuilder.build(JSON.parse(data.data));
         }
-        return data.data
+        if (fileType === "yaml") {
+            return yaml.dump(JSON.parse(data.data));
+        }
+        return data.data;
     } else {
-        throw new Error(data.message)
+        throw new Error(data.message);
     }
 }
 
@@ -33,23 +38,28 @@ export async function exportLocalFiles(content: string, langList: string[], file
         },
         body: JSON.stringify({
             content,
-            langList
+            langList,
+            fileType,
         }),
-    })
+    });
     const data = await res.json();
     if (data.success) {
-        if (fileType === "yaml") {
+        if (fileType === "xml") {
             for (let i = 0; i < data.data.length; i++) {
-                data.data[i].content = yaml.dump(JSON.parse(data.data[i].content))
+                data.data[i].content = xmlBuilder.build(JSON.parse(data.data[i].content));
+            }
+        } else if (fileType === "yaml") {
+            for (let i = 0; i < data.data.length; i++) {
+                data.data[i].content = yaml.dump(JSON.parse(data.data[i].content));
             }
         }
-        return data.data
+        return data.data;
     } else {
-        throw new Error(data.message)
+        throw new Error(data.message);
     }
 }
 
-export async function makeLocalesInZip (data: { lang: string, content: string }[], fileType: FileType): Promise<File> {
+export async function makeLocalesInZip(data: { lang: string; content: string }[], fileType: FileType): Promise<File> {
     const zipFileWriter = new BlobWriter();
     const zipWriter = new ZipWriter(zipFileWriter);
     for (let item of data) {
@@ -61,10 +71,10 @@ export async function makeLocalesInZip (data: { lang: string, content: string }[
 }
 
 export function downloadFileFromBlob(content: Blob, fileName: string) {
-    const ele = document.createElement('a');
-    ele.setAttribute('href', URL.createObjectURL(content));
-    ele.setAttribute('download', fileName);
-    ele.style.display = 'none';
+    const ele = document.createElement("a");
+    ele.setAttribute("href", URL.createObjectURL(content));
+    ele.setAttribute("download", fileName);
+    ele.style.display = "none";
     document.body.appendChild(ele);
     ele.click();
 

--- a/src/pages/translate/types.ts
+++ b/src/pages/translate/types.ts
@@ -1,1 +1,0 @@
-export type FileType = "json" | "yaml";

--- a/src/pages/translate/utils.ts
+++ b/src/pages/translate/utils.ts
@@ -1,23 +1,47 @@
-import { FileType } from "./types"
+import xml from "fast-xml-parser";
 import yaml from "js-yaml";
+
+export type FileType = "json" | "yaml" | "xml";
+
+const xmlOptions = {
+    ignoreAttributes: false,
+    allowBooleanAttributes: true,
+    attributeNamePrefix: "@_",
+    preserverOrder: true,
+};
+
+export const xmlParser = new xml.XMLParser(xmlOptions);
+export const xmlBuilder = new xml.XMLBuilder({ ...xmlOptions, format: true });
 
 export function compress(content: string, fileType: FileType): string {
     try {
-        return fileType === "json" ? JSON.stringify(JSON.parse(content)) : JSON.stringify(yaml.load(content)) as string;
+        if (fileType === "xml") {
+            return JSON.stringify(xmlParser.parse(content));
+        }
+        if (fileType === "yaml") {
+            return JSON.stringify(yaml.load(content));
+        }
+        return JSON.stringify(JSON.parse(content));
     } catch (error) {
-        throw new Error(`${fileType} is not valid`)
+        throw new Error(`${fileType} is not valid`);
     }
 }
 
-export function prettierJson(content: string, fileType: FileType): string {
+export function prettify(content: string, fileType: FileType): string {
     try {
-        return fileType === "json" ? JSON.stringify(JSON.parse(content), null, 2) : yaml.dump(yaml.load(content)) as string;
+        if (fileType === "xml") {
+            return xmlBuilder.build(xmlParser.parse(content));
+        }
+        if (fileType === "yaml") {
+            yaml.dump(yaml.load(content));
+        }
+        return JSON.stringify(JSON.parse(content), null, 2);
     } catch (error) {
-        throw new Error('json is not valid')
+        throw new Error(`${fileType} is not valid`);
     }
 }
 
 // copy content to clipboard
-export function copy2Clipboard(content: string) {
-    navigator.clipboard.writeText(content)
+export function copy2clipboard(content: string) {
+    navigator.clipboard.writeText(content);
 }


### PR DESCRIPTION
@ObservedObserver @kyze8439690 I have introduced an option to translate `XML` files (implemented the feature requested in #11) by utilizing the `xml2js` library. However, if a tag contains a period (.) like in android (e.g., `androidx.constraintLayout.widget.ConstraintLayout`), it will split the tag at the dots into multiple tags, as this is the logic employed to construct the new JSON. I did not want to interfere with this process, but I will attempt to address this issue shortly.