### PR TITLE
Update OpenAI chat completion API endpoint

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -65,7 +65,7 @@ export async function createChatCompletion(props: ICreateChatCompletionProps, co
     }
     if (config.serviceProvider === 'openai') {
         // openai chat completion
-        url = 'https://api.openai.com/v1/engines/davinci/completions'
+        url = 'https://api.openai.com/v1/chat/completions'
         headers['Authorization'] = `Bearer ${config.apiKey}`
     } else if (config.serviceProvider === 'azure') {
         headers['api-key'] = `${config.apiKey}`


### PR DESCRIPTION
You get this error in the current state when translating via the Frontend
```javascript
{
    "error": {
        "message": "Cannot specify both model and engine",
        "type": "invalid_request_error",
        "param": null,
        "code": null
    }
}
``` 
Emphasis on `Cannot specify both model and engine`

This is because the request [body](https://github.com/ObservedObserver/chatgpt-i18n/blob/main/src/utils/index.ts#L78-L80) contains the model

Example
```javascript
{
    "model": "gpt-3.5-turbo",
    "messages": [
        {
            "role": "system",
            "content": "You are a helpful assistant that translates a i18n locale array content to Spanish. \n            It's a array structure, contains many strings, translate each of them and make a new array of translated strings.\n            Consider all the string as a context to make better translation.\n"
        },
        {
            "role": "user",
            "content": "Translate this array: \n\n\n"
        },
        {
            "role": "user",
            "content": "[\"My Project\"]"
        }
    ],
    "temperature": 0
}
```